### PR TITLE
Support plain passwords in Maven settings.xml for tools.deps compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ flycheck_*.el
 /checkouts
 pom.xml
 pom.xml.asc
-*.jar
+*.pom.asc
+*.jar.asc
 *.class
 /.cpcache
 /.lein-*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Clojars Project](https://img.shields.io/clojars/v/jp.xcoo/deps-deploy.svg)](https://clojars.org/jp.xcoo/deps-deploy)
+
 # deps-deploy
 
 A Clojure library to deploy your stuff to clojars with `clj` or `clojure`. It's a very thin wrapper around
@@ -17,6 +18,7 @@ To deploy to Clojars, simply merge
                        :sign-releases? true
                        :artifact "deps-deploy.jar"}}}
 ```
+
 into your `deps.edn`, have a `pom.xml` handy (you can generate one with `clj -Spom`), and deploy with
 
 ```sh
@@ -30,6 +32,7 @@ It is also possible to override the default Clojars URL by supplying your own. F
 ```sh
 $ env CLOJARS_URL=https://internal/repository/maven-releases CLOJARS_USERNAME=username CLOJARS_PASSWORD=password clj -A:deploy
 ```
+
 This facilitates deploying artefacts to an internal repository - perhaps a proxy service that is running locally that is used
 to hold private JARs etc...
 
@@ -54,6 +57,7 @@ To deploy to private s3 buckets, you first need to specify the `:repository` key
 ```clj
 :exec-args {:repository {"releases" {:url "s3p://my/bucket/"}}}
 ```
+
 Then, when deploying, you need to provide credentials which is done either by:
 
 1. setting the env vars: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
@@ -67,6 +71,7 @@ or
 aws_access_key_id = AKIAXXXXX
 aws_secret_access_key = SECRET_KEY
 ```
+
 For more details see [s3-wagon-provider](https://github.com/s3-wagon-private/s3-wagon-private#aws-credential-providers) and if you need to know how to [configure an S3 bucket see here](https://github.com/s3-wagon-private/s3-wagon-private#aws-policy).
 
 ### A note on Clojars tokens
@@ -79,6 +84,7 @@ Long story short, just go find yourself a token and use it in lieu of your passw
 ## Install locally
 
 `deps-deploy` also supports installing to your local `.m2` repo, by invoking `install` instead of `deploy`:
+
 ```clojure
 {:install {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "RELEASE"}}
            :exec-fn deps-deploy.deps-deploy/deploy
@@ -89,12 +95,14 @@ Long story short, just go find yourself a token and use it in lieu of your passw
 ## Signing
 
 If you want to have your artifacts signed, add `"true"` as the last element of the `:main-opts` vector like so:
+
 ```clojure
 :main-opts ["-m" "deps-deploy.deps-deploy" "install"
             "path/to/my.jar" "true"]
 ```
 
 If you don't want to use the default key for signing, you can specify the key id:
+
 ```clojure
 :main-opts ["-m" "deps-deploy.deps-deploy" "install"
             "path/to/my.jar" "true" "1C33430999AA1C3C243A302689CACBAD9979E3C5"]
@@ -104,5 +112,6 @@ If you don't want to use the default key for signing, you can specify the key id
 
 Copyright © 2018-2021 Erik Assum
 
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+Copyright © 2025 [Xcoo, Inc.](https://xcoo.jp/)
+
+Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars Project](https://img.shields.io/clojars/v/slipset/deps-deploy.svg)](https://clojars.org/slipset/deps-deploy)
+[![Clojars Project](https://img.shields.io/clojars/v/xcoo/deps-deploy.svg)](https://clojars.org/xcoo/deps-deploy)
 # deps-deploy
 
 A Clojure library to deploy your stuff to clojars with `clj` or `clojure`. It's a very thin wrapper around
@@ -11,7 +11,7 @@ It will read your Clojars username/token from the environment variables `CLOJARS
 To deploy to Clojars, simply merge
 
 ```clojure
-{:deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -36,7 +36,7 @@ to hold private JARs etc...
 If you want to sign using another key than the default key, you can specify the signing key id:
 
 ```clojure
-{:deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -80,7 +80,7 @@ Long story short, just go find yourself a token and use it in lieu of your passw
 
 `deps-deploy` also supports installing to your local `.m2` repo, by invoking `install` instead of `deploy`:
 ```clojure
-{:install {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
+{:install {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :local
                        :artifact "deps-deploy.jar"}}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars Project](https://img.shields.io/clojars/v/xcoo/deps-deploy.svg)](https://clojars.org/xcoo/deps-deploy)
+[![Clojars Project](https://img.shields.io/clojars/v/jp.xcoo/deps-deploy.svg)](https://clojars.org/jp.xcoo/deps-deploy)
 # deps-deploy
 
 A Clojure library to deploy your stuff to clojars with `clj` or `clojure`. It's a very thin wrapper around
@@ -11,7 +11,7 @@ It will read your Clojars username/token from the environment variables `CLOJARS
 To deploy to Clojars, simply merge
 
 ```clojure
-{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -36,7 +36,7 @@ to hold private JARs etc...
 If you want to sign using another key than the default key, you can specify the signing key id:
 
 ```clojure
-{:deploy {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
+{:deploy {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "RELEASE"}}
           :exec-fn deps-deploy.deps-deploy/deploy
           :exec-args {:installer :remote
                        :sign-releases? true
@@ -80,7 +80,7 @@ Long story short, just go find yourself a token and use it in lieu of your passw
 
 `deps-deploy` also supports installing to your local `.m2` repo, by invoking `install` instead of `deploy`:
 ```clojure
-{:install {:extra-deps {xcoo/deps-deploy {:mvn/version "RELEASE"}}
+{:install {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "RELEASE"}}
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :local
                        :artifact "deps-deploy.jar"}}

--- a/deps.edn
+++ b/deps.edn
@@ -28,13 +28,13 @@
                                  :version     :mvn/version
                                  :sync-pom true}}
 
-           :deploy {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0-SNAPSHOT"}}
+           :deploy {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0"}}
                     :exec-fn deps-deploy.deps-deploy/deploy
                     :exec-args {:installer :remote
                                 :sign-releases? true
                                 :artifact :jar/file-name}}
 
-           :install {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0-SNAPSHOT"}}
+           :install {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0"}}
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
                                  :artifact :jar/file-name}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        clj-commons/pomegranate {:mvn/version "1.2.23"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+        clj-commons/pomegranate {:mvn/version "1.2.24"}
         s3-wagon-private/s3-wagon-private {:mvn/version "1.3.5"}
-        org.clojure/data.xml {:mvn/version "0.2.0-alpha8"}
-        org.clojure/tools.deps {:mvn/version "0.18.1354"}
-        org.apache.maven/maven-settings {:mvn/version "3.9.4"}
-        org.apache.maven/maven-settings-builder {:mvn/version "3.9.4"}
+        org.clojure/data.xml {:mvn/version "0.2.0-alpha9"}
+        org.clojure/tools.deps {:mvn/version "0.21.1467"}
+        org.apache.maven/maven-settings {:mvn/version "3.9.9"}
+        org.apache.maven/maven-settings-builder {:mvn/version "3.9.9"}
         org.slf4j/slf4j-nop {:mvn/version "RELEASE"}
         org.sonatype.plexus/plexus-sec-dispatcher {:mvn/version "1.4"}}
 
@@ -15,8 +15,8 @@
                   :exec-fn cognitect.test-runner.api/test}
 
            :mvn/artifact-id deps-deploy
-           :mvn/group-id    slipset
-           :mvn/version     "0.2.1"
+           :mvn/group-id    jp.xcoo
+           :mvn/version     "0.3.0-SNAPSHOT"
            :jar/file-name   "deps-deploy.jar"
 
            :depstar {:replace-deps
@@ -28,13 +28,13 @@
                                  :version     :mvn/version
                                  :sync-pom true}}
 
-           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+           :deploy {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0-SNAPSHOT"}}
                     :exec-fn deps-deploy.deps-deploy/deploy
                     :exec-args {:installer :remote
                                 :sign-releases? true
                                 :artifact :jar/file-name}}
 
-           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+           :install {:extra-deps {jp.xcoo/deps-deploy {:mvn/version "0.3.0-SNAPSHOT"}}
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
                                  :artifact :jar/file-name}}

--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,7 @@
                      :exec-fn deps-deploy.deps-deploy/deploy
                      :exec-args {:installer :local
                                  :artifact :jar/file-name}}
+
            :outdated {;; Note that it is `:deps`, not `:extra-deps`
                       :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
                       :main-opts ["-m" "antq.core"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
 
            :mvn/artifact-id deps-deploy
            :mvn/group-id    jp.xcoo
-           :mvn/version     "0.3.0-SNAPSHOT"
+           :mvn/version     "0.3.0"
            :jar/file-name   "deps-deploy.jar"
 
            :depstar {:replace-deps

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,12 @@
   <artifactId>deps-deploy</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <name>deps-deploy</name>
+  <licenses>
+    <license>
+      <name>Eclipse Public License 1.0</name>
+      <url>https://www.eclipse.org/org/documents/epl-1.0/EPL-1.0.txt</url>
+    </license>
+  </licenses>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -30,7 +36,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.16</version>
+      <version>2.1.0-alpha1</version>
     </dependency>
     <dependency>
       <groupId>s3-wagon-private</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>jp.xcoo</groupId>
   <artifactId>deps-deploy</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.0</version>
   <name>deps-deploy</name>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -2,35 +2,35 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
-  <groupId>slipset</groupId>
+  <groupId>jp.xcoo</groupId>
   <artifactId>deps-deploy</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0-SNAPSHOT</version>
   <name>deps-deploy</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
-      <version>3.9.4</version>
+      <version>3.9.9</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.xml</artifactId>
-      <version>0.2.0-alpha8</version>
+      <version>0.2.0-alpha9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.9</version>
+      <version>2.0.16</version>
     </dependency>
     <dependency>
       <groupId>s3-wagon-private</groupId>
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.deps</artifactId>
-      <version>0.18.1354</version>
+      <version>0.21.1467</version>
     </dependency>
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>pomegranate</artifactId>
-      <version>1.2.23</version>
+      <version>1.2.24</version>
     </dependency>
   </dependencies>
   <build>

--- a/test/deps_deploy/deps_deploy_test.clj
+++ b/test/deps_deploy/deps_deploy_test.clj
@@ -1,7 +1,0 @@
-(ns deps-deploy.deps-deploy-test
-  (:require [clojure.test :refer :all]
-            [deps-deploy.deps-deploy :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))


### PR DESCRIPTION
I added support for a plain password in the Maven settings.xml to ensure compatibility with `tools.deps`. 

As you may know, `tools.deps` currently does not support encrypted passwords in the Maven settings.xml. For more details, please refer to https://clojure.atlassian.net/browse/TDEPS-255.